### PR TITLE
Fix randomInt NaN bug

### DIFF
--- a/packages/workflow/src/utils.ts
+++ b/packages/workflow/src/utils.ts
@@ -254,11 +254,12 @@ export function randomInt(min: number, max: number): number;
  * @returns {number} A random integer within the specified range.
  */
 export function randomInt(min: number, max?: number): number {
-	if (max === undefined) {
-		max = min;
-		min = 0;
-	}
-	return min + (crypto.getRandomValues(new Uint32Array(1))[0] % (max - min));
+        if (max === undefined) {
+                max = min;
+                min = 0;
+        }
+        if (max <= min) return min;
+        return min + (crypto.getRandomValues(new Uint32Array(1))[0] % (max - min));
 }
 
 export function randomString(length: number): string;

--- a/packages/workflow/test/utils.test.ts
+++ b/packages/workflow/test/utils.test.ts
@@ -259,13 +259,20 @@ describe('randomInt', () => {
 		});
 	});
 
-	it('should generate random in range', () => {
-		repeat(() => {
-			const result = randomInt(10, 100);
-			expect(result).toBeLessThanOrEqual(100);
-			expect(result).toBeGreaterThanOrEqual(10);
-		});
-	});
+        it('should generate random in range', () => {
+                repeat(() => {
+                        const result = randomInt(10, 100);
+                        expect(result).toBeLessThanOrEqual(100);
+                        expect(result).toBeGreaterThanOrEqual(10);
+                });
+        });
+
+       it('should return min when min equals max', () => {
+               repeat(() => {
+                       const result = randomInt(5, 5);
+                       expect(result).toBe(5);
+               });
+       });
 });
 
 describe('randomString', () => {


### PR DESCRIPTION
## Summary
- avoid NaN when min and max are equal in `randomInt`
- add a regression test

## Testing
- `pnpm test --filter=workflow --run-tests` *(fails: unable to fetch packages)*